### PR TITLE
BSD port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC ?= gcc
 CFLAGS ?= -Wall -Wstrict-prototypes
-CFLAGS += -fPIC
+CFLAGS += -fPIC -pthread
 LDFLAGS += -shared
 LIBRARY=libnss_cache.so.2.0
 BASE_LIBRARY=libnss_cache.so.2

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ SONAME=libnss_cache.so.2
 LD_SONAME=-Wl,-soname,$(SONAME)
 TESTDATA=.testdata
 
+LIBNSSCACHE = nss_cache.o compat/getpwent_r.o compat/getgrent_r.o
+
 SOURCES = Makefile gen_getent.c lookup.c nss_cache.c nss_cache.h nss_test.h COPYING version libnss-cache.spec
 VERSION = $(shell cat version)
 
@@ -17,7 +19,7 @@ all: $(LIBRARY)
 
 check: test_getent time_lookups
 
-lookup: lookup.o nss_cache.o
+lookup: lookup.o $(LIBNSSCACHE)
 	$(CC) $(CFLAGS) -o $@ $^
 
 time_lookups: testdirs lookup_data lookup
@@ -53,7 +55,7 @@ time_lookups: testdirs lookup_data lookup
 	../vendetta/files/gen_cache.py $(TESTDATA)/shadow.cache 1 $(TESTDATA)/shadow.cache.ixname
 	time -f %E lookup -c getspnam -f $(TESTDATA)/rand_spnames
 
-gen_getent: gen_getent.o nss_cache.o
+gen_getent: gen_getent.o $(LIBNSSCACHE)
 	$(CC) -o $@ $^
 
 
@@ -86,14 +88,14 @@ last_pw_errno_test: test/last_pw_errno_test.c
 testdirs:
 	mkdir -p $(TESTDATA)
 
-$(LIBRARY): nss_cache.o compat/getpwent_r.o compat/getgrent_r.o
+$(LIBRARY): $(LIBNSSCACHE)
 	$(CC) $(CFLAGS) $(LDFLAGS) $(LD_SONAME) -o $(LIBRARY) $+
 
 clean:
 	rm -f $(LIBRARY) *.o compat/*.o lookup gen_getent last_pw_errno_test
 	rm -rf $(TESTDATA)
 
-install: all 
+install: all
 	install -d $(LIBDIR)
 	install $(LIBRARY) $(LIBDIR)
 	ln -sf $(LIBRARY) $(LIBDIR)/$(BASE_LIBRARY)

--- a/Makefile
+++ b/Makefile
@@ -86,8 +86,8 @@ last_pw_errno_test: test/last_pw_errno_test.c
 testdirs:
 	mkdir -p $(TESTDATA)
 
-$(LIBRARY): nss_cache.o
-	$(CC) $(CFLAGS) $(LDFLAGS) $(LD_SONAME) -o $(LIBRARY) $<
+$(LIBRARY): nss_cache.o compat/getpwent_r.o compat/getgrent_r.o
+	$(CC) $(CFLAGS) $(LDFLAGS) $(LD_SONAME) -o $(LIBRARY) $+
 
 clean:
 	rm -f $(LIBRARY) *.o lookup gen_getent last_pw_errno_test

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC ?= gcc
-CFLAGS ?= -Wall -Wstrict-prototypes -Werror
+CFLAGS ?= -Wall -Wstrict-prototypes
 CFLAGS += -fPIC
 LDFLAGS += -shared
 LIBRARY=libnss_cache.so.2.0

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ $(LIBRARY): nss_cache.o compat/getpwent_r.o compat/getgrent_r.o
 	$(CC) $(CFLAGS) $(LDFLAGS) $(LD_SONAME) -o $(LIBRARY) $+
 
 clean:
-	rm -f $(LIBRARY) *.o lookup gen_getent last_pw_errno_test
+	rm -f $(LIBRARY) *.o compat/*.o lookup gen_getent last_pw_errno_test
 	rm -rf $(TESTDATA)
 
 install: all 

--- a/bsdnss.c
+++ b/bsdnss.c
@@ -1,0 +1,48 @@
+NSS_METHOD_PROTOTYPE(__nss_compat_getpwnam_r);
+NSS_METHOD_PROTOTYPE(__nss_compat_getpwuid_r);
+NSS_METHOD_PROTOTYPE(__nss_compat_getpwent_r);
+NSS_METHOD_PROTOTYPE(__nss_compat_setpwent);
+NSS_METHOD_PROTOTYPE(__nss_compat_endpwent);
+NSS_METHOD_PROTOTYPE(__nss_compat_getgrnam_r);
+NSS_METHOD_PROTOTYPE(__nss_compat_getgrgid_r);
+NSS_METHOD_PROTOTYPE(__nss_compat_getgrent_r);
+NSS_METHOD_PROTOTYPE(__nss_compat_setgrent);
+NSS_METHOD_PROTOTYPE(__nss_compat_endgrent);
+
+enum nss_status _nss_cache_getpwnam_r (const char *, struct passwd *, char *,
+                                  size_t, int *);
+enum nss_status _nss_cache_getpwuid_r (uid_t, struct passwd *, char *,
+                                  size_t, int *);
+enum nss_status _nss_cache_getpwent_r (struct passwd *, char *, size_t, int *);
+enum nss_status _nss_cache_setpwent (int);
+enum nss_status _nss_cache_endpwent (void);
+
+enum nss_status _nss_cache_getgrnam_r (const char *, struct group *, char *,
+                                  size_t, int *);
+enum nss_status _nss_cache_getgrgid_r (gid_t, struct group *, char *,
+                                  size_t, int *);
+enum nss_status _nss_cache_getgrent_r (struct group *, char *, size_t, int *);
+enum nss_status _nss_cache_setgrent (int);
+enum nss_status _nss_cache_endgrent (void);
+
+static ns_mtab methods[] = {
+    { NSDB_PASSWD, "getpwnam_r", __nss_compat_getpwnam_r, _nss_cache_getpwnam_r },
+    { NSDB_PASSWD, "getpwuid_r", __nss_compat_getpwuid_r, _nss_cache_getpwuid_r },
+    { NSDB_PASSWD, "getpwent_r", __nss_compat_getpwent_r, _nss_cache_getpwent_r },
+    { NSDB_PASSWD, "endpwent",   __nss_compat_endpwent,   _nss_cache_endpwent },
+    { NSDB_PASSWD, "setpwent",   __nss_compat_setpwent,   _nss_cache_setpwent },
+    { NSDB_GROUP,  "getgrnam_r", __nss_compat_getgrnam_r, _nss_cache_getgrnam_r },
+    { NSDB_GROUP,  "getgrgid_r", __nss_compat_getgrgid_r, _nss_cache_getgrgid_r },
+    { NSDB_GROUP,  "getgrent_r", __nss_compat_getgrent_r, _nss_cache_getgrent_r },
+    { NSDB_GROUP,  "endgrent",   __nss_compat_endgrent,   _nss_cache_endgrent },
+    { NSDB_GROUP,  "setgrent",   __nss_compat_setgrent,   _nss_cache_setgrent },
+};
+
+ns_mtab *
+nss_module_register (const char *name, unsigned int *size,
+                     nss_module_unregister_fn *unregister)
+{
+    *size = sizeof (methods) / sizeof (methods[0]);
+    *unregister = NULL;
+    return (methods);
+}

--- a/compat/getgrent_r.c
+++ b/compat/getgrent_r.c
@@ -1,0 +1,117 @@
+/*
+ * ----------------------------------------------------------------------
+ *  Copyright © 2005-2014 Rich Felker, et al.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining
+ *  a copy of this software and associated documentation files (the
+ *  "Software"), to deal in the Software without restriction, including
+ *  without limitation the rights to use, copy, modify, merge, publish,
+ *  distribute, sublicense, and/or sell copies of the Software, and to
+ *  permit persons to whom the Software is furnished to do so, subject to
+ *  the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be
+ *  included in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ *  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ *  CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ *  TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ *  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *  ----------------------------------------------------------------------
+ *
+ *  Adapted from http://www.musl-libc.org/ for libnss-cache
+ */
+
+#include <sys/param.h>
+
+#ifdef __FreeBSD__
+
+#include <grp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <errno.h>
+#include <string.h>
+
+static char **mem;
+
+static unsigned atou(char **s)
+{
+	unsigned x;
+	for (x=0; **s-'0'<10U; ++*s) x=10*x+(**s-'0');
+	return x;
+}
+
+int __getgrent_a(FILE *f, struct group *gr, char **line, size_t *size, char ***mem, size_t *nmem, struct group **res)
+{
+	/* LIBNSS_CACHE_DEL ssize_t l; */
+	char *s, *mems;
+	size_t i;
+	int rv = 0;
+	int cs;
+	pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &cs);
+	for (;;) {
+		line[0][(*size)-1] = '\xff';
+		/* LIBNSS_CACHE_DIFF if ((l=getline(line, size, f)) < 0) { */
+		if ( (fgets(*line, *size, f) == NULL) || ferror(f) || (line[0][(*size)-1] != '\xff') ) {
+			/* LIBNSS_CACHE_DIFF rv = ferror(f) ? errno : 0; */
+			rv = (line[0][(*size)-1] != '\xff') ? ERANGE : ENOENT;
+			/* LIBNSS_CACHE_DEL free(*line); */
+			*line = 0;
+			gr = 0;
+			goto end;
+		}
+		/* LIBNSS_CACHE_DEL line[0][l-1] = 0; */
+		line[0][strcspn(line[0], "\n")] = 0;
+
+		s = line[0];
+		gr->gr_name = s++;
+		if (!(s = strchr(s, ':'))) continue;
+
+		*s++ = 0; gr->gr_passwd = s;
+		if (!(s = strchr(s, ':'))) continue;
+
+		*s++ = 0; gr->gr_gid = atou(&s);
+		if (*s != ':') continue;
+
+		*s++ = 0; mems = s;
+		break;
+	}
+
+	for (*nmem=!!*s; *s; s++)
+		if (*s==',') ++*nmem;
+	free(*mem);
+	*mem = calloc(sizeof(char *), *nmem+1);
+	if (!*mem) {
+		rv = errno;
+		/* LIBNSS_CACHE_DEL free(*line); */
+		*line = 0;
+		/* LIBNSS_CACHE_DIFF return 0; */
+		return rv;
+	}
+	if (*mems) {
+		mem[0][0] = mems;
+		for (s=mems, i=0; *s; s++)
+			if (*s==',') *s++ = 0, mem[0][++i] = s;
+		mem[0][++i] = 0;
+	} else {
+		mem[0][0] = 0;
+	}
+	gr->gr_mem = *mem;
+end:
+	pthread_setcancelstate(cs, 0);
+	*res = gr;
+	if(rv) errno = rv;
+	return rv;
+}
+
+int fgetgrent_r(FILE *f, struct group *gr, char *line, size_t size, struct group **res)
+{
+	size_t nmem=0;
+	return __getgrent_a(f, gr, &line, &size, &mem, &nmem, res);
+}
+
+#endif // ifdef __FreeBSD__

--- a/compat/getgrent_r.c
+++ b/compat/getgrent_r.c
@@ -27,7 +27,7 @@
 
 #include <sys/param.h>
 
-#ifdef __FreeBSD__
+#ifdef BSD
 
 #include <grp.h>
 #include <stdio.h>
@@ -114,4 +114,4 @@ int fgetgrent_r(FILE *f, struct group *gr, char *line, size_t size, struct group
 	return __getgrent_a(f, gr, &line, &size, &mem, &nmem, res);
 }
 
-#endif // ifdef __FreeBSD__
+#endif // ifdef BSD

--- a/compat/getpwent_r.c
+++ b/compat/getpwent_r.c
@@ -27,7 +27,7 @@
 
 #include <sys/param.h>
 
-#ifdef __FreeBSD__
+#ifdef BSD
 
 #include <pwd.h>
 #include <stdio.h>
@@ -97,4 +97,4 @@ int fgetpwent_r(FILE *f, struct passwd *pw, char *line, size_t size, struct pass
 	return __fgetpwent_a(f, pw, &line, &size, res);
 }
 
-#endif // ifdef __FreeBSD__
+#endif // ifdef BSD

--- a/compat/getpwent_r.c
+++ b/compat/getpwent_r.c
@@ -1,0 +1,100 @@
+/*
+ * ----------------------------------------------------------------------
+ *  Copyright © 2005-2014 Rich Felker, et al.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining
+ *  a copy of this software and associated documentation files (the
+ *  "Software"), to deal in the Software without restriction, including
+ *  without limitation the rights to use, copy, modify, merge, publish,
+ *  distribute, sublicense, and/or sell copies of the Software, and to
+ *  permit persons to whom the Software is furnished to do so, subject to
+ *  the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be
+ *  included in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ *  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ *  CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ *  TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ *  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *  ----------------------------------------------------------------------
+ *
+ *  Adapted from http://www.musl-libc.org/ for libnss-cache
+ */
+
+#include <sys/param.h>
+
+#ifdef __FreeBSD__
+
+#include <pwd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <errno.h>
+#include <string.h>
+
+static unsigned atou(char **s)
+{
+	unsigned x;
+	for (x=0; **s-'0'<10U; ++*s) x=10*x+(**s-'0');
+	return x;
+}
+
+int __fgetpwent_a(FILE *f, struct passwd *pw, char **line, size_t *size, struct passwd **res)
+{
+	/* LIBNSS_CACHE_DEL ssize_t l; */
+	char *s;
+	int rv = 0;
+	int cs;
+	pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &cs);
+	for (;;) {
+		line[0][(*size)-1] = '\xff';
+		/* LIBNSS_CACHE_DEL if ((l=getline(line, size, f)) < 0) { */
+		if ( (fgets(*line, *size, f) == NULL) || ferror(f) || (line[0][(*size)-1] != '\xff') ) {
+			/* LIBNSS_CACHE_DIFF rv = ferror(f) ? errno : 0; */
+			rv = (line[0][(*size)-1] != '\xff') ? ERANGE : ENOENT;
+			/* LIBNSS_CACHE_DEL free(*line); */
+			*line = 0;
+			pw = 0;
+			break;
+		}
+		/* LIBNSS_CACHE_DEL line[0][l-1] = 0; */
+		line[0][strcspn(line[0], "\n")] = 0;
+
+		s = line[0];
+		pw->pw_name = s++;
+		if (!(s = strchr(s, ':'))) continue;
+
+		*s++ = 0; pw->pw_passwd = s;
+		if (!(s = strchr(s, ':'))) continue;
+
+		*s++ = 0; pw->pw_uid = atou(&s);
+		if (*s != ':') continue;
+
+		*s++ = 0; pw->pw_gid = atou(&s);
+		if (*s != ':') continue;
+
+		*s++ = 0; pw->pw_gecos = s;
+		if (!(s = strchr(s, ':'))) continue;
+
+		*s++ = 0; pw->pw_dir = s;
+		if (!(s = strchr(s, ':'))) continue;
+
+		*s++ = 0; pw->pw_shell = s;
+		break;
+	}
+	pthread_setcancelstate(cs, 0);
+	*res = pw;
+	if (rv) errno = rv;
+	return rv;
+}
+
+int fgetpwent_r(FILE *f, struct passwd *pw, char *line, size_t size, struct passwd **res)
+{
+	return __fgetpwent_a(f, pw, &line, &size, res);
+}
+
+#endif // ifdef __FreeBSD__

--- a/gen_getent.c
+++ b/gen_getent.c
@@ -109,6 +109,7 @@ static int getgrent_to_file(FILE *output) {
   return 0;
 }
 
+#ifndef BSD
 // getspent_to_file()
 // Call the nss_cache getspent function to dump the shadow store to a
 // file.
@@ -180,6 +181,7 @@ static int getspent_to_file(FILE *output) {
 
   return 0;
 }
+#endif // ifndef BSD
 
 // gen_getpwent_data()
 //
@@ -231,6 +233,7 @@ static int gen_getgrent_data(void) {
   return ret;
 }
 
+#ifndef BSD
 // gen_getspent_data()
 //
 // creates a copy of the shadow map as read by nss_cache.c
@@ -255,6 +258,7 @@ static int gen_getspent_data(void) {
 
   return ret;
 }
+#endif // ifndef BSD
 
 // main()
 //
@@ -278,11 +282,13 @@ int main(void) {
     failed_tests = failed_tests + 1;
   }
 
+#ifndef BSD
   ret = gen_getspent_data();
   if (ret != 0) {
     fprintf(stderr, "Failed to generate password file.\n");
     failed_tests = failed_tests + 1;
   }
+#endif
 
   printf("generated all files.\n");
 

--- a/lookup.c
+++ b/lookup.c
@@ -207,6 +207,7 @@ static int getgrgid_wrapper(gid_t gid) {
   return found;
 }
 
+#ifndef BSD
 // getspnam_wrapper()
 //
 // perform a getspnam() lookup via nss_cache.c directly
@@ -247,6 +248,7 @@ static int getspnam_wrapper(char *name) {
 
   return found;
 }
+#endif // ifndef BSD
 
 // lookup_getpwnam()
 //
@@ -372,6 +374,7 @@ static int lookup_getgrgid(FILE *input) {
   return ret;
 }
 
+#ifndef BSD
 // lookup_getspnam()
 //
 // call getspnam() from nss_cache.c on each line of a file
@@ -402,6 +405,7 @@ static int lookup_getspnam(FILE *input) {
 
   return ret;
 }
+#endif // ifndef BSD
 
 // nss_lookup()
 //
@@ -419,8 +423,10 @@ static int nss_lookup(char *call, FILE *input) {
     ret = lookup_getgrnam(input);
   } else if (strncmp(call, "getgrgid", 8) == 0) {
     ret = lookup_getgrgid(input);
+#ifndef BSD
   } else if (strncmp(call, "getspnam", 8) == 0) {
     ret = lookup_getspnam(input);
+#endif // ifndef BSD
   } else {
     fprintf(stderr, "unknown nss function: %s\n", call);
     ret = 1;

--- a/nss_cache.c
+++ b/nss_cache.c
@@ -38,10 +38,15 @@ static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 
 static FILE *p_file = NULL;
 static FILE *g_file = NULL;
-static FILE *s_file = NULL;
 static char p_filename[NSS_CACHE_PATH_LENGTH] = "/etc/passwd.cache";
 static char g_filename[NSS_CACHE_PATH_LENGTH] = "/etc/group.cache";
+#ifndef __FreeBSD__
+static FILE *s_file = NULL;
 static char s_filename[NSS_CACHE_PATH_LENGTH] = "/etc/shadow.cache";
+#else
+extern int fgetpwent_r(FILE *, struct passwd *, char *, size_t, struct passwd **);
+extern int fgetgrent_r(FILE *, struct group *, char *, size_t, struct group **);
+#endif // ifndef __FreeBSD__
 
 /* Common return code routine for all *ent_r_locked functions.
  * We need to return TRYAGAIN if the underlying files guy raises ERANGE,
@@ -734,6 +739,7 @@ enum nss_status _nss_cache_getgrnam_r(const char *name, struct group *result,
 //
 //  Routines for shadow map defined here.
 //
+#ifndef __FreeBSD__
 
 // _nss_cache_setspent_path()
 // Helper function for testing
@@ -923,3 +929,6 @@ enum nss_status _nss_cache_getspnam_r(const char *name, struct spwd *result,
 
   return ret;
 }
+#else
+#include "bsdnss.c"
+#endif // ifndef __FreeBSD__

--- a/nss_cache.c
+++ b/nss_cache.c
@@ -40,13 +40,13 @@ static FILE *p_file = NULL;
 static FILE *g_file = NULL;
 static char p_filename[NSS_CACHE_PATH_LENGTH] = "/etc/passwd.cache";
 static char g_filename[NSS_CACHE_PATH_LENGTH] = "/etc/group.cache";
-#ifndef __FreeBSD__
+#ifndef BSD
 static FILE *s_file = NULL;
 static char s_filename[NSS_CACHE_PATH_LENGTH] = "/etc/shadow.cache";
 #else
 extern int fgetpwent_r(FILE *, struct passwd *, char *, size_t, struct passwd **);
 extern int fgetgrent_r(FILE *, struct group *, char *, size_t, struct group **);
-#endif // ifndef __FreeBSD__
+#endif // ifndef BSD
 
 /* Common return code routine for all *ent_r_locked functions.
  * We need to return TRYAGAIN if the underlying files guy raises ERANGE,
@@ -739,7 +739,7 @@ enum nss_status _nss_cache_getgrnam_r(const char *name, struct group *result,
 //
 //  Routines for shadow map defined here.
 //
-#ifndef __FreeBSD__
+#ifndef BSD
 
 // _nss_cache_setspent_path()
 // Helper function for testing
@@ -931,4 +931,4 @@ enum nss_status _nss_cache_getspnam_r(const char *name, struct spwd *result,
 }
 #else
 #include "bsdnss.c"
-#endif // ifndef __FreeBSD__
+#endif // ifndef BSD

--- a/nss_cache.h
+++ b/nss_cache.h
@@ -21,14 +21,18 @@
 #include <nss.h>
 #include <stdlib.h>
 #include <pwd.h>
-#include <shadow.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/param.h>
 #include <time.h>
 #include <unistd.h>
+
+#ifndef __FreeBSD__
+#include <shadow.h>
+#endif // ifndef __FreeBSD__
 
 #ifndef NSS_CACHE_H
 #define NSS_CACHE_H
@@ -48,7 +52,9 @@
 #define NSS_CACHE_PATH_LENGTH 255
 extern char *_nss_cache_setpwent_path(const char *path);
 extern char *_nss_cache_setgrent_path(const char *path);
+#ifndef __FreeBSD__
 extern char *_nss_cache_setspent_path(const char *path);
+#endif // ifndef __FreeBSD__
 
 enum nss_cache_match {
   NSS_CACHE_EXACT = 0,

--- a/nss_cache.h
+++ b/nss_cache.h
@@ -30,9 +30,9 @@
 #include <time.h>
 #include <unistd.h>
 
-#ifndef __FreeBSD__
+#ifndef BSD
 #include <shadow.h>
-#endif // ifndef __FreeBSD__
+#endif // ifndef BSD
 
 #ifndef NSS_CACHE_H
 #define NSS_CACHE_H
@@ -52,9 +52,9 @@
 #define NSS_CACHE_PATH_LENGTH 255
 extern char *_nss_cache_setpwent_path(const char *path);
 extern char *_nss_cache_setgrent_path(const char *path);
-#ifndef __FreeBSD__
+#ifndef BSD
 extern char *_nss_cache_setspent_path(const char *path);
-#endif // ifndef __FreeBSD__
+#endif // ifndef BSD
 
 enum nss_cache_match {
   NSS_CACHE_EXACT = 0,

--- a/nss_test.h
+++ b/nss_test.h
@@ -20,14 +20,20 @@
 #include <unistd.h>
 #include <pwd.h>
 #include <grp.h>
+#include <sys/param.h>
+
+#ifndef BSD
 #include <shadow.h>
+#endif // ifndef BSD
 
 #ifndef NSS_TEST_H
 #define NSS_TEST_H
 
 const char *PASSWD_FILE = ".testdata/passwd.cache";
 const char *GROUP_FILE = ".testdata/group.cache";
+#ifndef BSD
 const char *SHADOW_FILE = ".testdata/shadow.cache";
+#endif // ifndef BSD
 
 extern enum nss_status _nss_cache_getpwent_r(struct passwd *result,
                                              char *buffer, size_t buflen,
@@ -47,11 +53,13 @@ extern enum nss_status _nss_cache_getgrnam_r(const char *name,
 extern enum nss_status _nss_cache_getgrgid_r(gid_t gid, struct group *result,
                                              char *buffer, size_t buflen,
                                              int *errnop);
+#ifndef BSD
 extern enum nss_status _nss_cache_getspnam_r(const char *name,
                                              struct spwd *result, char *buffer,
                                              size_t buflen, int *errnop);
 extern enum nss_status _nss_cache_getspent_r(struct spwd *result, char *buffer,
                                              size_t buflen, int *errnop);
 extern char *_nss_cache_setpwent_path(const char *path);
+#endif // ifndef BSD
 
 #endif /* NSS_TEST_H */


### PR DESCRIPTION
This PR allows for libnss-cache to build on FreeBSD.

There are two minor changes to the Makefile that I will handle in the FreeBSD ports tree (soname needs to be nss_{name}.so.1), and setting the prefix dynamically (to /usr/local usually).

The fget*ent_r functions are adapted from musl libc (MIT licensed).  I'm fairly comfortable with fgetpwent_r.  I don't fully understand the mem and nmem stuff going on in __fgetgrent_a; empirically it works but I do not know if the memory is allocated and freed righteously.  Any review there would be great.

Thanks for the awesome code.  We're going to run this on our boxes that run large quantities of interwebs awesomely using FreeBSD at @llnw.