### PR TITLE
freebsd libthr stability fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC ?= gcc
 CFLAGS ?= -Wall -Wstrict-prototypes
-CFLAGS += -fPIC -pthread
+CFLAGS += -fPIC
 LDFLAGS += -shared
 LIBRARY=libnss_cache.so.2.0
 BASE_LIBRARY=libnss_cache.so.2

--- a/compat/getgrent_r.c
+++ b/compat/getgrent_r.c
@@ -79,7 +79,8 @@ int fgetgrent_r(FILE *f, struct group *gr, char *line, size_t size, struct group
 	for (nmem=!!*s; *s; s++)
 		if (*s==',') ++nmem;
 
-	remain = (void *) &line[size] - (void *) &line[ep+1];
+	++ep;
+	remain = (void *) &line[size] - (void *) &line[ep];
 	need = (sizeof(char *) * (nmem+1)) + ALIGNBYTES;
 	if (need > remain) {
 		rv = ERANGE;
@@ -87,8 +88,8 @@ int fgetgrent_r(FILE *f, struct group *gr, char *line, size_t size, struct group
 		gr = 0;
 		goto end;
 	}
-	memset(&line[ep+1], 0, need);
-	gr->gr_mem = (char **) ALIGN(&line[ep+1]);
+	memset(&line[ep], 0, need);
+	gr->gr_mem = (char **) ALIGN(&line[ep]);
 
 	if (*mems) {
 		gr->gr_mem[0] = mems;

--- a/compat/getgrent_r.c
+++ b/compat/getgrent_r.c
@@ -79,7 +79,7 @@ int fgetgrent_r(FILE *f, struct group *gr, char *line, size_t size, struct group
 	for (nmem=!!*s; *s; s++)
 		if (*s==',') ++nmem;
 
-	remain = (void *) &line[size-1] - (void *) &line[ep+1];
+	remain = (void *) &line[size] - (void *) &line[ep+1];
 	need = (sizeof(char *) * (nmem+1)) + ALIGNBYTES;
 	if (need > remain) {
 		rv = ERANGE;


### PR DESCRIPTION
The main fix here for what I thought https://github.com/google/nsscache/issues/43 was is dropping -pthread like you originally had.

libthr still has some fragility around dynamically loading pthreads in mixed linkage https://www.freebsd.org/news/status/report-2015-01-2015-03.html#libthr-improvements