### PR TITLE
Specifying files within the lib directory 

### DIFF
--- a/libnss-cache.spec
+++ b/libnss-cache.spec
@@ -33,7 +33,7 @@ make LIBDIR="%{buildroot}%{_libdir}" install
 
 %files
 %defattr(-, root, root, 0755)
-%{_libdir}
+%{_libdir}/*
 
 %changelog
 * Mon Mar 07 2016 Kevin Bowling <kbowling@freebsd.org> - 0.15-1


### PR DESCRIPTION
This is to prevent conflicts with filesystem package which seems to be a common problem since CentOS 7.  