### PR TITLE
Allow multiple packages architectures to be installed.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,6 +10,7 @@ Vcs-Git: https://github.com/google/libnss-cache -b debian
 
 Package: libnss-cache
 Architecture: any
+Multi-Arch: same
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Recommends: nsscache
 Description: NSS module for using nsscache-generated files


### PR DESCRIPTION
Add `Multi-Arch: same` to allow parallel installation.

Fixes #6