### PR TITLE
Adjust logic for compat shims.

### DIFF
--- a/compat/getgrent_r.c
+++ b/compat/getgrent_r.c
@@ -26,9 +26,9 @@
  *  Copyright © 2015 Kevin Bowling <k@kev009.com>
  */
 
-#include <sys/param.h>
-
-#ifdef BSD
+// This compat layer is only built for BSD, or Linux without the GNU C
+// Library.
+#if defined(BSD) || (defined(__linux__) && !defined(__GLIBC__))
 
 #include <grp.h>
 #include <stddef.h>
@@ -37,6 +37,16 @@
 #include <errno.h>
 #include <string.h>
 
+#if defined(BSD)
+#include <sys/param.h>
+#else
+// This branch is necessarily Linux and not GNU because of the checks
+// defined above that guard the rest of the compat layer.  On Linux we
+// don't pull in param.h as it is very obsolete.
+#include <stdint.h>
+#define ALIGNBYTES _Alignof(max_align_t)
+#define ALIGN(p)(((uintptr_t)(p) + ALIGNBYTES & ~ALIGNBYTES))
+#endif // defined(BSD)
 static unsigned atou(char **s)
 {
 	unsigned x;
@@ -104,5 +114,4 @@ end:
 	if(rv) errno = rv;
 	return rv;
 }
-
-#endif // ifdef BSD
+#endif //#if defined(BSD) || defined(__LINUX__) && !defined(__GLIBC__)

--- a/compat/getpwent_r.c
+++ b/compat/getpwent_r.c
@@ -26,9 +26,9 @@
  *  Copyright © 2015 Kevin Bowling <k@kev009.com>
  */
 
-#include <sys/param.h>
-
-#ifdef BSD
+// This compat layer is only built for BSD, or Linux without the GNU C
+// Library.
+#if defined(BSD) || (defined(__linux__) && !defined(__GLIBC__))
 
 #include <pwd.h>
 #include <stdio.h>
@@ -83,5 +83,4 @@ int fgetpwent_r(FILE *f, struct passwd *pw, char *line, size_t size, struct pass
 	if (rv) errno = rv;
 	return rv;
 }
-
-#endif // ifdef BSD
+#endif //#if defined(BSD) || defined(__LINUX__) && !defined(__GLIBC__)

--- a/nss_cache.c
+++ b/nss_cache.c
@@ -730,7 +730,10 @@ enum nss_status _nss_cache_getgrnam_r(const char *name, struct group *result,
 //
 //  Routines for shadow map defined here.
 //
-#ifndef BSD
+#if defined(__LINUX__) && defined(__GLIBC__)
+// This is only built on GLIBC as caching the shadow file is generally
+// not permissable from the perspective of other libc's, so the
+// symbols are simply unused in those environments.
 
 // _nss_cache_setspent_path()
 // Helper function for testing
@@ -915,6 +918,8 @@ enum nss_status _nss_cache_getspnam_r(const char *name, struct spwd *result,
 
   return ret;
 }
-#else
+#endif
+
+#ifdef BSD
 #include "bsdnss.c"
-#endif  // ifndef BSD
+#endif  // #if defined(__LINUX__) && defined(__GLIBC__)


### PR DESCRIPTION
This PR adjusts the logic that chooses when the compat shims get built.  The immediate use case is to permit the use of libnss_cache with the excellent musl C library on Linux.  I've made what I believe to be the minimal set of changes that will work here, but there is a hazy line around the patch I have to replace the use of sys/param.h on Linux.

A special thanks to @Vaelatern for assisting with debugging while working on this PR.