### PR TITLE
build: `test` and `check` targets both generate coverage info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ debian/debhelper-build-stamp
 /libnss_cache.so
 /*.c.gcov
 /build/
+*.gcda
+*.gcno

--- a/Makefile
+++ b/Makefile
@@ -20,13 +20,10 @@ INDEX_DATA_TOUCH = $(TESTDATA)/.touch.index_data
 .PHONY: all
 all: $(LIBRARY)
 
-.PHONY: test
-test: test_getent time_lookups
-
-.PHONY: check
-check: CFLAGS += -O0 -g --coverage
-check: LDFLAGS += --coverage
-check: test_getent time_lookups
+.PHONY: test check
+test check: CFLAGS += -O0 -g --coverage
+test check: LDFLAGS += --coverage
+test check: test_getent time_lookups
 
 lookup: lookup.o $(LIBNSSCACHE)
 


### PR DESCRIPTION
Previously, the test Makefile target didn't set `CFLAGS` correctly and then
failed the tests because the coverage info didn't exist.

Also add the `gcno`/`gcda` extensions to the ignore list.