### PR TITLE
Add .clang-format to match current formatting.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,2 @@
+BasedOnStyle: Google
+PointerAlignment: Right

--- a/compat/getgrent_r.c
+++ b/compat/getgrent_r.c
@@ -110,4 +110,4 @@ end:
   if (rv) errno = rv;
   return rv;
 }
-#endif  //#if defined(BSD) || defined(__linux__) && !defined(__GLIBC__)
+#endif  // #if defined(BSD) || defined(__linux__) && !defined(__GLIBC__)

--- a/compat/getpwent_r.c
+++ b/compat/getpwent_r.c
@@ -89,4 +89,4 @@ int fgetpwent_r(FILE *f, struct passwd *pw, char *line, size_t size,
   if (rv) errno = rv;
   return rv;
 }
-#endif  //#if defined(BSD) || defined(__linux__) && !defined(__GLIBC__)
+#endif  // #if defined(BSD) || defined(__linux__) && !defined(__GLIBC__)


### PR DESCRIPTION
It looks like an update to clang-format-action may have changed the default, as the code was previously formatted with clang-format (64c067d).

Apply resulting style to a couple of comments.